### PR TITLE
More efficient softmax implementation

### DIFF
--- a/src/configure/configurable.rs
+++ b/src/configure/configurable.rs
@@ -144,7 +144,9 @@ pub mod configurable_sampler {
         let mut opts = slf.sampler_options();
 
         let (_omd, Some(optidx)) = opts.find_option_definition(key)? else {
-            Err(ConfigureSamplerError::CannotAccessOptionValue(key.to_string()))?
+            Err(ConfigureSamplerError::CannotAccessOptionValue(
+                key.to_string(),
+            ))?
         };
 
         Ok(match opts[optidx].1.take().expect("Impossible") {

--- a/src/configure/metadata.rs
+++ b/src/configure/metadata.rs
@@ -78,10 +78,10 @@ impl<T> SamplerOptions<T> {
         });
         let Some((optdef, optidx)) = it.next() else {
             Err(ConfigureSamplerError::UnknownOrBadType(if key.is_empty() {
-                        "<unspecified>".to_string()
-                } else {
-                    key.to_string()
-                }))?
+                "<unspecified>".to_string()
+            } else {
+                key.to_string()
+            }))?
         };
 
         if it.next().is_some() {

--- a/src/samplers/mirostat.rs
+++ b/src/samplers/mirostat.rs
@@ -127,7 +127,9 @@ where
             ))?
         }
         let Some(n_vocab) = L::from(n_vocab) else {
-            Err(LogitsError::InternalError("Cannot convert n_vocab to sampler logits type".to_string()))?
+            Err(LogitsError::InternalError(
+                "Cannot convert n_vocab to sampler logits type".to_string(),
+            ))?
         };
         let (zero, one, two) = (L::zero(), L::one(), L::one() + L::one());
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -180,9 +180,9 @@ impl<TID: CanTokenId, L: CanLogit> Logits<TID, L> {
             l.prob = l.logit.exp();
             sum = sum + l.prob;
         }
-        let cum_sum = sum / max_l.powi(self.logits.len() as i32).exp();
-        // e^(x-y) = e^x / e^y
-        self.iter_mut().for_each(|l| l.prob = l.prob / cum_sum);
+        let max_l_exp = max_l.exp();
+        let cum_sum = sum / max_l_exp.powi(self.logits.len() as i32);
+        self.iter_mut().for_each(|l| l.prob = (l.prob * max_l_exp) / cum_sum);
         Ok(self)
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -182,7 +182,7 @@ impl<TID: CanTokenId, L: CanLogit> Logits<TID, L> {
         }
         let max_l_exp = max_l.exp();
         let cum_sum = sum / max_l_exp.powi(self.logits.len() as i32);
-        self.iter_mut().for_each(|l| l.prob = (l.prob * max_l_exp) / cum_sum);
+        self.iter_mut().for_each(|l| l.prob = (l.prob / max_l_exp) / cum_sum);
         Ok(self)
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -170,8 +170,11 @@ impl<TID: CanTokenId, L: CanLogit> Logits<TID, L> {
         if self.is_empty() {
             return Ok(self);
         }
-        self.ensure_sorted()?;
-        let max_l = self[0].logit;
+        let max_l = if self.sorted{
+            self[0].logit
+        } else {
+            self.iter().map(|l| l.logit).fold(L::neg_infinity(), |a, b| a.max(b))
+        };
         let cum_sum = self.iter_mut().fold(L::zero(), |cs, l| {
             let p = (l.logit - max_l).exp();
             l.prob = p;

--- a/src/types.rs
+++ b/src/types.rs
@@ -181,8 +181,11 @@ impl<TID: CanTokenId, L: CanLogit> Logits<TID, L> {
             sum = sum + l.prob;
         }
         let max_l_exp = max_l.exp();
-        let cum_sum = sum / max_l_exp.powi(self.logits.len() as i32);
-        self.iter_mut().for_each(|l| l.prob = (l.prob / max_l_exp) / cum_sum);
+        let cum_sum = sum / max_l_exp;
+        for l in self.iter_mut(){
+            l.prob = (l.prob / max_l_exp) / cum_sum;
+            debug_assert!(l.prob >= L::zero() && l.prob <= L::one());
+        }
         Ok(self)
     }
 


### PR DESCRIPTION
Thanks for making llm-samplers! I am using it in [kalosm](https://github.com/floneum/floneum/tree/master/kalosm) to allow custom samplers for candle models. When I was benchmarking the performance of the models about 1/2 of the total time spent on the phi model was sorting the logit array in the `softmax` function. In Kalosm, after this change it took ~2% of the total inference time.

The current softmax implementation can trigger sorting the logits. This PR changes the softmax implementation to find the maximum logit with a simple loop instead.